### PR TITLE
columns,+columns options

### DIFF
--- a/lib/Teng/Plugin/SearchJoined.pm
+++ b/lib/Teng/Plugin/SearchJoined.pm
@@ -9,7 +9,7 @@ use Teng::Plugin::SearchJoined::Iterator;
 use SQL::Maker;
 SQL::Maker->load_plugin('JoinSelect');
 
-our @EXPORT = qw/search_joined/;
+our @EXPORT = qw/search_joined _get_select_joined_columns/;
 
 sub search_joined {
     my ($self, $base_table, $join_conditions, $where, $opt) = @_;
@@ -22,7 +22,7 @@ sub search_joined {
     }
     my @tables = map { $self->{schema}->get_table($_) } @table_names;
 
-    my $fields = _get_select_joined_columns($self, \@tables, $opt);
+    my $fields = $self->_get_select_joined_columns(\@tables, $opt);
 
     my ($sql, @binds) = $self->{sql_builder}->join_select($base_table, $join_conditions, $fields, $where, $opt);
     my $sth = $self->execute($sql, \@binds);

--- a/lib/Teng/Plugin/SearchJoined.pm
+++ b/lib/Teng/Plugin/SearchJoined.pm
@@ -54,7 +54,7 @@ sub _get_select_joined_columns {
     }
 
     if ($opt->{'+columns'}) {
-        push @fields => @{$opt->{'+columns'}}
+        push @fields, @{$opt->{'+columns'}}
     }
 
     return \@fields;

--- a/lib/Teng/Plugin/SearchJoined.pm
+++ b/lib/Teng/Plugin/SearchJoined.pm
@@ -22,15 +22,9 @@ sub search_joined {
     }
     my @tables = map { $self->{schema}->get_table($_) } @table_names;
 
-    my $name_sep = $self->{sql_builder}{name_sep};
-    my @fields;
-    for my $table (@tables) {
-        my $table_name = $table->name;
-        my @columns = map { "$table_name$name_sep$_" } @{ $table->columns };
-        push @fields, @columns;
-    }
+    my $fields = _get_select_joined_columns($self, \@tables, $opt);
 
-    my ($sql, @binds) = $self->{sql_builder}->join_select($base_table, $join_conditions, \@fields, $where, $opt);
+    my ($sql, @binds) = $self->{sql_builder}->join_select($base_table, $join_conditions, $fields, $where, $opt);
     my $sth = $self->execute($sql, \@binds);
     my $itr = Teng::Plugin::SearchJoined::Iterator->new(
         teng        => $self,
@@ -38,10 +32,32 @@ sub search_joined {
         sql         => $sql,
         table_names => \@table_names,
         suppress_object_creation => $self->{suppress_row_objects},
-        fields      => \@fields,
+        fields      => $fields,
     );
 
     $itr;
+}
+
+sub _get_select_joined_columns {
+    my ($self, $tables, $opt) = @_;
+
+    if ($opt->{columns}) {
+        return $opt->{columns}
+    }
+
+    my @fields;
+    my $name_sep = $self->{sql_builder}{name_sep};
+    for my $table (@$tables) {
+        my $table_name = $table->name;
+        my @columns = map { "$table_name$name_sep$_" } @{ $table->columns };
+        push @fields, @columns;
+    }
+
+    if ($opt->{'+columns'}) {
+        push @fields => @{$opt->{'+columns'}}
+    }
+
+    return \@fields;
 }
 
 1;

--- a/lib/Teng/Plugin/SearchJoined/Iterator.pm
+++ b/lib/Teng/Plugin/SearchJoined/Iterator.pm
@@ -43,9 +43,14 @@ sub _seperate_rows {
     my $name_sep = quotemeta $self->{teng}{sql_builder}{name_sep};
     my $i = 0;
     for my $field (@{ $self->{fields} }) {
-        my $value = $row->[$i++];
+        my $value = $row->[$i];
         my ($table, $column) = split /$name_sep/, $field;
+        if (!$column) {
+            $column = $self->{sth}->{NAME_lc}->[$i];
+            $table  = $self->{table_names}->[0]; # base_table
+        }
         $data{$table}{$column} = $value;
+        $i++;
     }
     \%data;
 }

--- a/lib/Teng/Plugin/SearchJoined/Iterator.pm
+++ b/lib/Teng/Plugin/SearchJoined/Iterator.pm
@@ -44,10 +44,13 @@ sub _seperate_rows {
     my $i = 0;
     for my $field (@{ $self->{fields} }) {
         my $value = $row->[$i];
-        my ($table, $column) = split /$name_sep/, $field;
-        if (!$column) {
+        my ($table, $column);
+        if (ref $field) {
             $column = $self->{sth}->{NAME_lc}->[$i];
             $table  = $self->{table_names}->[0]; # base_table
+        }
+        else {
+            ($table, $column) = split /$name_sep/, $field;
         }
         $data{$table}{$column} = $value;
         $i++;


### PR DESCRIPTION
add `columns` and `+columns` search options, as same as Teng.

e.g.

``` perl
# columns opts
my $itr = $db->search_joined(user_item => [
    item => {'user_item.item_id' => 'item.id'},
], {
    'item.id' => 1,
}, {
    'columns'  => ['item.id'],
});
$itr->{sql}
# =>
# SELECT `item`.`id`
# FROM `user_item` INNER JOIN `item` ON `user_item`.`item_id` = `item`.`id`
# WHERE (`item`.`id` = ?)
```

``` perl
# +columns opts
my $itr = $db->search_joined(user_item => [
    item => {'user_item.item_id' => 'item.id'},
], {
    'item.id' => 1,
}, {
    '+columns'  => [\'item.id * 10 AS item_num'],
});
$itr->{sql}
# =>
# SELECT `user_item`.`id`, `user_item`.`user_id`, `user_item`.`item_id`, `item`.`id`, `item`.`name_en`, item.id * 10 AS item_num
# FROM `user_item` INNER JOIN `item` ON `user_item`.`item_id` = `item`.`id`
# WHERE (`item`.`id` = ?)

# get  `+columns` by base_table row.
my ($user_item, $item) = $itr->next;
$user_item->item_num # => 10
```
